### PR TITLE
Update ArduinoJson version in platformio as well

### DIFF
--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -11,7 +11,9 @@ board_build.filesystem = littlefs
 lib_deps =
   Adafruit BMP280 Library@2.1.0
   Adafruit NeoPixel@1.6.0
-  ArduinoJson@6.16.1
+  ArduinoJson@6.17.1
   PubSubClient@2.8
   SparkFun SCD30 Arduino Library@1.0.8
   https://github.com/tzapu/WiFiManager/archive/2.0.3-alpha.zip
+#  https://github.com/jalr/EE895
+  ../../EE895


### PR DESCRIPTION
From now on, we should keep the dependencies' versions in [README](Software/README.md) and [platformio](Software/platformio.ini) in sync.